### PR TITLE
Fix bullets in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ ludology: the study of Games
 This package is for the study of Games, mathematical abstractions for the analysis of partizan games.
 
 A partizan game is one such that:
+
 * there are two players, Left and Right, who alternate turns
 * there are no random elements (dice, shuffled cards, etc)
 * there is no sequence of play which causes the state of the game to repeat


### PR DESCRIPTION
I ran the sphinx and it fixed these bullets:
![image](https://user-images.githubusercontent.com/2541209/44541872-246f3680-a6c0-11e8-95da-5cc2d9c786db.png)

vs 
https://ludology.readthedocs.io/en/latest/index.html